### PR TITLE
Remove Eli May

### DIFF
--- a/people.json
+++ b/people.json
@@ -1264,23 +1264,6 @@
       "image":"https://www.cncf.io/wp-content/uploads/2019/02/1517454267644.jpg"
    },
    {
-      "name":"Eli May",
-      "bio":"Eli is a Public Relations Manager for CNCF.",
-      "company":"Public Relations Manager",
-      "pronouns":"he/him",
-      "linkedin":"https://www.linkedin.com/in/elimay/",
-      "twitter":"",
-      "github":"",
-      "wechat":"",
-      "website":"",
-      "youtube":"",
-      "priority":"",
-      "category":[
-         "Staff"
-      ],
-      "image":"https://www.cncf.io/wp-content/uploads/2020/08/eli-may-1.jpg"
-   },
-   {
       "name":"Elna Vogel",
       "bio":"<p>Elna is a Meeting &amp; Event Planner at The Linux Foundation, mainly working on CNCF events, and managing events with Chinese aspects.&nbsp;&nbsp;</p>\n\n<p>Elna has extensive track records leading cross-functional events globally. Prior to joining the Linux Foundation, Elna produced and managed corporate events for Fortune 500 investment banks in Hong Kong such as State Street, Goldman Sachs and BNY Mellon. Fluent in English, Mandarin and Cantonese, she works effortlessly across all regions, countries and cultures.&nbsp;</p>",
       "company":"Event & Meeting Planner",


### PR DESCRIPTION
Signed-off-by: Taylor Dolezal <onlydole@gmail.com>

Remove Eli May as he no longer works for the CNCF.