### PR TITLE
Add config.yml PR Check, docs on additional fields

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,3 +12,22 @@ jobs:
         env:
           INPUT_SCHEMA: /schema.json
           INPUT_JSONS: /people.json
+  verify-config-yaml:
+    runs-on: ubuntu-latest
+    env:
+      SHERIFF_IMPORTANT_BRANCH: main
+      SHERIFF_PLUGINS: cncfSlack
+      PERMISSIONS_FILE_ORG: cncf
+      PERMISSIONS_FILE_REPO: people
+      PR_FILE_ORG: ${{ github.actor }}
+      PR_FILE_REPO: ${GITHUB_REPOSITORY#*/}
+      PR_FILE_REF: ${{ github.ref_name }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SHERIFF_GITHUB_APP_CREDS: ${{ secrets.SHERIFF_GITHUB_APP_CREDS }}
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+      GSUITE_CREDENTIALS: ${{ secrets.GSUITE_CREDENTIALS }}
+    container:
+      image: us.gcr.io/cncf-slack-infra/sheriff/sheriff:cncf-slack-plugin
+    steps:
+      - name: Do a dry-run with Sheriff to validate configs and output changes
+        run: node lib/permissions/run.js

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,22 +12,3 @@ jobs:
         env:
           INPUT_SCHEMA: /schema.json
           INPUT_JSONS: /people.json
-  verify-config-yaml:
-    runs-on: ubuntu-latest
-    env:
-      SHERIFF_IMPORTANT_BRANCH: main
-      SHERIFF_PLUGINS: cncfSlack
-      PERMISSIONS_FILE_ORG: cncf
-      PERMISSIONS_FILE_REPO: people
-      PR_FILE_ORG: ${{ github.actor }}
-      PR_FILE_REPO: ${GITHUB_REPOSITORY#*/}
-      PR_FILE_REF: ${{ github.ref_name }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SHERIFF_GITHUB_APP_CREDS: ${{ secrets.SHERIFF_GITHUB_APP_CREDS }}
-      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-      GSUITE_CREDENTIALS: ${{ secrets.GSUITE_CREDENTIALS }}
-    container:
-      image: us.gcr.io/cncf-slack-infra/sheriff/sheriff:cncf-slack-plugin
-    steps:
-      - name: Do a dry-run with Sheriff to validate configs and output changes
-        run: node lib/permissions/run.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The [people.json file](https://github.com/cncf/people/blob/main/people.json) lis
         "languages":[Array of languages spoken],
         "projects":[Array of CNCF projects of expertise],
         "category":[Array of categories the person belongs to],
+        "email": "person!example.com",
+        "slack_id": "U123ABC456",
         "image":"Image filename from the /images/ directory"
     }
 ```
@@ -49,6 +51,8 @@ And here is an example entry:
         "languages":["Spanish","English"],
         "projects":["prometheus","kubernetes","envoy"],
         "category":["Ambassadors"],
+        "email": "johnny!example.com",
+        "slack_id": "U123ABC456",
         "image":"jappleseed.jpg"
     }
 ```
@@ -56,3 +60,14 @@ And here is an example entry:
 ## Images
 
 Upload your headshot image to the `/images/` directory with a filename made up of your name.  Images should be at least 500x500px, 72dpi, and should be in JPG format with file size less than 100kB.
+
+## Team Management
+
+Also within this repo is a YAML file used by our [automation tooling](https://github.com/electronjs/sheriff) to help us manage access to resources for teams. This tooling takes advantage of data in [people.json](people.json) such as the `email` and `slack_id` fields. This will allow us to add maintainers to different properties only using their GitHub handle. 
+
+* To find your Slack ID for the CNCF slack, please follow this [handy guide](https://moshfeu.medium.com/how-to-find-my-member-id-in-slack-workspace-d4bba942e38c)
+
+* When adding your email, please follow the same format used within [devstats](https://github.com/cncf/devstats):
+  ```
+  email!address.xyz
+  ```


### PR DESCRIPTION
With [Sheriff](https://github.com/electronjs/sheriff) eventually helping us manage Slack and other tooling, we need to rally around a repo that has things like user data and team configs. So this PR adds docs on what new fields exit (`slack_id` and `email`) ~and creates a PR check that runs Sheriff (as a dry-run!) to validate people.json/config.yaml changes.~

Due to limitations with GHA secret handling, we can't actually do a PR check 🙃 This is something to be worked on in the future, but for now we should get notified of a bad apply via Slack.