### PR TITLE
Add End User team to Private End User repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -389,8 +389,9 @@ repositories:
       idvoretskyi: write
       onlydole: admin
       taylorwaggoner: admin
-    name: enduser
+  - name: enduser
     visibility: private
+    teams: cncf-end-users
   - name: enduser-public
   - external_collaborators:
       alexkontsevoy: write


### PR DESCRIPTION
Associate the End User GitHub team with the private GitHub repository.