### PR TITLE
Add `ramrodo` to cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -471,6 +471,7 @@ repositories:
       meryem-ldn: read
       mitul3737: write
       raelga: write
+      ramrodo: write      
       same7ammar: write
       sayantani11: write
       seokho-son: admin


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently added a new localization approver (@ramrodo) to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/1704

I guess we need to update config.yaml in cncf/people in order to follow the new CNCF Sheriff bot.