### PR TITLE
Updating Landscape and Students repos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -538,6 +538,7 @@ repositories:
     external_collaborators:
       Swil78: write
       andreuxxxx: triage # Mentor for UI/UX project 2023 Mar-May
+      Hilzygift: read # Mentee for UI/UX project 2023 Mar-May
   - name: landscape
     teams:
       Landscapers: admin

--- a/config.yaml
+++ b/config.yaml
@@ -537,6 +537,7 @@ repositories:
       Landscapers: admin
     external_collaborators:
       Swil78: write
+      andreuxxxx: triage # Mentor for UI/UX project 2023 Mar-May
   - name: landscape
     teams:
       Landscapers: admin
@@ -699,6 +700,7 @@ repositories:
       savitharaghunathan: triage
       sergioarmgpl: triage
       xmulligan: admin
+      nate-double-u: admin
     name: students
     settings:
       has_wiki: true
@@ -1008,6 +1010,7 @@ teams:
       - lukaszgryglicki
   - maintainers:
       - jeefy
+      - nate-double-u
     members:
       - AndreyKozlov1984
       - lukaszgryglicki


### PR DESCRIPTION
As a part of https://github.com/cncf/landscape/issues/2467, and the possibility of a Students WG under TAG Contributor Strategy:
* Adding Nate W. (@nate-double-u) to Landscape and Students repos as admin
* Adding Andrea V. (@andreuxxxx) to Landscape as triage
* Adding Hilda O. (@Hilzygift) to Landscape as read

/cc @caniszczyk @RobertKielty @jeefy 