### PR TITLE
adds maintainers to cncf-tech-docs

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: us.gcr.io/cncf-slack-infra/sheriff/sheriff:cncf-slack-plugin
       env:
-        PERMISSIONS_FILE_ORG: ${{ github.event.pull_request.organization.name }}
+        PERMISSIONS_FILE_ORG: ${{ github.event.repository.owner.name }}  
         SHERIFF_HOST_URL: 'https://sheriff-ajrw3kq6ta-uc.a.run.app'
         SHERIFF_PLUGINS: cncfSlack
         PERMISSIONS_FILE_REPO: ${{ github.event.pull_request.repository.name }}

--- a/config.yaml
+++ b/config.yaml
@@ -984,9 +984,11 @@ repository_defaults:
   has_wiki: false
 teams:
   - name: cncf-tech-docs
-    members:
+    maintainers:
       - nate-double-u
+      - jeefy
       - amye
+    members:
       - caniszczyk
       - chalin
       - idvoretskyi


### PR DESCRIPTION
I did not include maintainers on my last PR for cncf-tech-docs and this caused sheriff permission sync to not run to completion. (Now a GH Action here!)

This PR adds maintainers to the team.