### PR TITLE
hard codes cncf as the org being managed by cncf/sheriff

### DIFF
--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: us.gcr.io/cncf-slack-infra/sheriff/sheriff:cncf-slack-plugin
       env:
-        PERMISSIONS_FILE_ORG: ${{ github.event.repository.owner.name }}  
+        PERMISSIONS_FILE_ORG: 'cncf'
         SHERIFF_HOST_URL: 'https://sheriff-ajrw3kq6ta-uc.a.run.app'
         SHERIFF_PLUGINS: cncfSlack
         PERMISSIONS_FILE_REPO: ${{ github.event.pull_request.repository.name }}

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -16,7 +16,7 @@ jobs:
         PERMISSIONS_FILE_ORG: 'cncf'
         SHERIFF_HOST_URL: 'https://sheriff-ajrw3kq6ta-uc.a.run.app'
         SHERIFF_PLUGINS: cncfSlack
-        PERMISSIONS_FILE_REPO: ${{ github.event.pull_request.repository.name }}
+        PERMISSIONS_FILE_REPO: 'people'
         SHERIFF_IMPORTANT_BRANCH: ${{ github.event.pull_request.base.ref }}
         GSUITE_CREDENTIALS: e30=
         SHERIFF_GITHUB_APP_CREDS: ${{ secrets.SHERIFF_GITHUB_APP_CREDS }}


### PR DESCRIPTION
Hard coding cncf as the org for PERMISSION_FILE_ORG for now

I really need to see Dry Run Action run to fix config.yaml team entries. 

This should help restore the cncf/sheriff to regular runs via GitHub Actions.

