### PR TITLE
fixes cncf-automation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,9 @@ repositories:
       Landscapers: write
     external_collaborators:
       alexcontini: write
+  - name: automation
+    teams:
+      cncf-automation: admin
   - external_collaborators:
       amye: admin
       caniszczyk: admin
@@ -1018,14 +1021,12 @@ repositories:
   - name: y2c
 repository_defaults:
   has_wiki: false
-  - name: automation
-    teams:
-      cncf-automation: admin
 teams:
   - name: cncf-automation
     maintainers:
-      - jeefy
       - RobertKielty
+    members:
+      - jeefy
   - name: cncf-tech-docs
     maintainers:
       - nate-double-u

--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ repositories:
       Landscapers: write
     external_collaborators:
       alexcontini: write
-- name: automation
+  - name: automation
     teams:
       cncf-automation: admin
   - external_collaborators:

--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ repositories:
       Landscapers: write
     external_collaborators:
       alexcontini: write
-  - name: automation
+- name: automation
     teams:
       cncf-automation: admin
   - external_collaborators:


### PR DESCRIPTION
Pushed last config.yaml change to main in error with an error, this _should_ fix that.

This adds a cncf-automation team and repo.