### PR TITLE
Giving thetwopct write access to tag-contributor-strategy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -797,6 +797,7 @@ repositories:
       nate-double-u: write
       parispittman: maintain
       thisisnotapril: write
+      thetwopct: write
     name: tag-contributor-strategy
   - external_collaborators:
       amye: admin


### PR DESCRIPTION
thetwopct (James Hunt) already had write access to contribute repo (now archived), this gives same permission on the merged tag-contributor-strategy repo