### PR TITLE
Add `sestegra` to cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -506,6 +506,7 @@ repositories:
       same7ammar: write
       sayantani11: write
       seokho-son: admin
+      sestegra: write
       sistella: write
       thetwopct: write
       ugho16: write


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently added a new localization approver (@sestegra) to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/1976

We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.