### PR TITLE
Add cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -505,6 +505,7 @@ repositories:
       krol3: write
       meryem-ldn: read
       mitul3737: write
+      pichuang: write
       raelga: write
       ramrodo: write
       same7ammar: write
@@ -515,6 +516,7 @@ repositories:
       thetwopct: write
       ugho16: write
       waleed318: write
+      ydFu: write
       yunkon-kim: write
     name: glossary
   - external_collaborators:


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently added new localization approvers (@pichuang @ydFu) to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/2003

We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.