### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -473,7 +473,6 @@ repositories:
       AShabana: write
       CathPag: maintain
       DaveVentura: write
-      Eviekim: write
       Garima-Negi: write
       Giulia-dipietro: write
       Imtiaz1234: write
@@ -497,12 +496,15 @@ repositories:
       fydrah: write
       hanyuancheung: write
       huats: write
-      iamNoah1: maintain
+      iamNoah1: admin
       ikramulkayes: write
+      inductor: write
       jayesh-srivastava: write
       jessicalins: write
-      jihoon-seo: maintain
+      jihoon-seo: admin
+      kaitoii11: write
       krol3: write
+      naonishijima: write
       meryem-ldn: read
       mitul3737: write
       pichuang: write


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently updated permissions for the cncf/glossary repository (https://github.com/cncf/glossary/pull/2046)

1. Add initial approvers for Japanese Localization based on the initiation request (#1422)
 Kohei Ota (@inductor)
 Nao Nishijima(@naonishijima)
  Kaito (@kaitoii11)

2. Change permission for @iamNoah1 @jihoon-seo from maintain to admin so that the maintainers can merge a PR related with branches 

3. Remove inactive localization approvers


We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.