### PR TITLE
adds TAG Contributor Strategy Teams

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -787,32 +787,13 @@ repositories:
       scottrigby: write
       thschue: admin
     name: tag-app-delivery
-  - external_collaborators:
-      CathPag: admin
-      LFCIBot: write
-      SaraTrap: write
-      amye: admin
-      caniszczyk: admin
-      carolynvs: admin
-      cathyhongzhang: write
-      dims: write
-      geekygirldawn: admin
-      hh: write
-      iennae: write
-      jaytiaki: write
-      jberkus: admin
-      juliasimon: write
-      justaugustus: maintain
-      karenhchu: write
-      kgamanji: write
-      mattfarina: write
-      mattklein123: write
-      mrbobbytables: write
-      nate-double-u: write
-      parispittman: maintain
-      thisisnotapril: write
-      thetwopct: write
-    name: tag-contributor-strategy
+  - name: tag-contributor-strategy
+    teams:
+      tcs-maintainers: admin
+      tcs-contributors: write
+      tcs-toc-liasons: write
+      tcs-burnout-and-inclusiveness: write
+      tcs-comminfra-leads: admin
   - external_collaborators:
       amye: admin
       caniszczyk: admin
@@ -1132,6 +1113,57 @@ teams:
     members:
       - mkorbi
       - nikimanoledaki
+  - name: tag-contributor-strategy
+    formation:
+      - tcs-maintainers
+      - tcs-contributors
+      - tcs-toc-liasons
+      - tcs-burnout-and-inclusiveness
+      - tcs-comminfra-leads
+  - name: tcs-maintainers
+    maintainers:
+      - geekygirldawn
+      - jberkus
+    members:
+      - CathPag
+  - name: tcs-contributors
+    maintainers:
+      - geekygirldawn
+      - jberkus
+    members:
+      - mrbobbytables
+      - justaugustus
+      - parispittman
+      - gerred
+      - mattklein123
+      - thisisnotapril
+      - karenhchu
+      - dims
+      - iennae
+      - LFCIBot
+  - name: tcs-toc-liasons
+    maintainers:
+      - geekygirldawn
+      - jberkus
+    members:
+      - TheFoxAtWork
+      - dzolotusky
+  - name: tcs-burnout-and-inclusiveness
+    maintainers:
+      - geekygirldawn
+      - jberkus
+    members:
+      - juliasimon
+      - mcgonagle
+      - melaniadeangelis
+      - SaraTrap
+      - jadeapplegate
+  - name: tcs-comminfra-leads
+    maintainers:
+      - geekygirldawn
+      - jberkus
+    members:
+      - hh
 #- name: ambassadors
 #- name: awards-maintainers
 #- name: bvs-team


### PR DESCRIPTION
This change brings cncf/people/config.yaml into line with the current [repo-local access perms in settings.xml](https://github.com/cncf/tag-contributor-strategy/blob/main/.github/settings.yml)

Once this change is reviewed merged and tested we can then remove the perms defines in settings.xml on repo.

Of note is my attempt to create teams based on the roles defined over on the TCS repo.

cc @jberkus @geekygirldawn @CathPag 
