### PR TITLE
Add new Tech Leads for TAG-Contributor Strategy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1130,6 +1130,8 @@ teams:
     members:
       - jberkus
       - CathPag
+      - Riaankl
+      - aliok
   - name: tcs-contributors
     maintainers:
       - geekygirldawn


### PR DESCRIPTION
Adding @aliok and @Riannkl as admins for TAG-Contributor strategy.

Follow-ups: both will need to be invited to CNCF org.

@RobertKielty 