### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -479,7 +479,7 @@ repositories:
       Imtiaz1234: write
       JasonMorgan: admin
       Krast76: write
-      Mouly22: write
+      Arindam200: write
       MrErlison: write
       Rocksnake: write
       Saim-Safdar: write
@@ -499,8 +499,9 @@ repositories:
       hanyuancheung: write
       huats: write
       iamNoah1: admin
-      ikramulkayes: write
+      sajibAdhi: write
       inductor: write
+      Jacob953: write
       jayesh-srivastava: write
       jessicalins: write
       jihoon-seo: admin
@@ -522,6 +523,10 @@ repositories:
       waleed318: write
       ydFu: write
       yunkon-kim: write
+      aliok: write
+      halil-bugol: write
+      developer-guy: write
+      eminalemdar: write
     name: glossary
   - external_collaborators:
       halcyondude: admin


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We hope to update permissions for the cncf/glossary repository based on..

1. Add Turkish approvers (external_collaborators with write) https://github.com/cncf/glossary/issues/2123
Add: @aliok
Add: @halil-bugol
Add: @developer-guy
Add: @eminalemdar

2. Replace Bengali localization approvers. https://github.com/cncf/glossary/pull/2100
Remove: @Mouly22 @ikramulkayes
Add: @Arindam200 @sajibAdhi

3. Re-Add a localization approver (I don't know why but an approver has been removed from the list)
Add: @Jacob953

