### PR TITLE
Update cncf/glossary external_collaborators (add `castrojo`)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -478,6 +478,7 @@ repositories:
   - external_collaborators:
       92nqb: write
       AShabana: write
+      castrojo: write
       CathPag: maintain
       DaveVentura: write
       Garima-Negi: write


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We hope to update permission for the cncf/glossary repository.

1. Add @castrojo to the list of English approvers (external_collaborators with write permission in cncf/glossary) based on https://github.com/cncf/glossary/pull/2183

