### PR TITLE
Add wg green reviews chairs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -827,9 +827,11 @@ repositories:
       caniszczyk: admin
       caradelia: maintain
       catblade: admin
+      guidemetothemoon: maintain
       leonardpahlke: admin
       mkorbi: admin
       nate-double-u: admin
+      nikimanoledaki: maintain
       chalin: maintain
     name: tag-env-sustainability
     settings:


### PR DESCRIPTION
The TAG ENV recently launched the WG Green Reviews and selected @guidemetothemoon and @nikimanoledaki as WG Chairs. This PR adds the two working group chairs to the TAG ENV repo. 

ref issue: https://github.com/cncf/tag-env-sustainability/issues/186

cc @nate-double-u @RobertKielty 