### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -538,6 +538,11 @@ repositories:
       halil-bugol: write
       developer-guy: write
       eminalemdar: write
+      shurup: write
+      kirkonru: write
+      hwchiu: write
+      johnlinp: write
+      yuichi-nakamura: write
     name: glossary
   - external_collaborators:
       halcyondude: admin


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We hope to update permissions for the cncf/glossary repository based on..

https://github.com/cncf/glossary/pull/2343

#### Localization approvers
- Add approvers for Russian Team based on https://github.com/cncf/glossary/pull/2220 
  - [x] @shurup 
  - [x] @kirkonru 
- Add approvers for Traditional Chinese Team based on https://github.com/cncf/glossary/pull/2321
  - [x] @hwchiu 
  - [x] @johnlinp 
- Add approver for Japanese Team based on https://github.com/cncf/glossary/issues/1422#issuecomment-1654752535
  - [x] @yuichi-nakamura 