### PR TITLE
Add Query Working Group Users to OBS TAG Repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -859,8 +859,10 @@ repositories:
       halcyondude: admin
       henrikrexed: write
       kenfinnigan: write
+      manolama: write
       mhausenblas: write
       resouer: admin
+      vjsamuel: write
     name: tag-observability
     settings:
       has_wiki: true


### PR DESCRIPTION
Adding Chris Larsen @manolama and Vijay Samuel @vjsamuel to the Observability TAG repo as writers to help with the Observability Query Language Standards working group. See https://github.com/cncf/tag-observability/blob/main/working-groups/query-standardization.md