### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -539,7 +539,7 @@ repositories:
       yunkon-kim: write
       aliok: write
       halil-bugol: write
-      developer-guy: write
+      rwxdash: write
       eminalemdar: write
       shurup: write
       kirkonru: write


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently removed existing localization approvers and added new approvers to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/2629

Add new approvers for Turkish based on a requested by the localization team.
- @rwxdash

Step down approvers for Turkish based on a requested by the localization team.
- @developer-guy


We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.