### PR TITLE
Add cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -518,6 +518,7 @@ repositories:
       naonishijima: write
       meryem-ldn: read
       mitul3737: write
+      Okabe-Junya: write
       pichuang: write
       raelga: write
       ramrodo: write


### PR DESCRIPTION
HI!!

I am one of the contributors of the https://github.com/cncf/glossary. I am interested in this project and decided to join Japanese localization approver team.

- https://github.com/cncf/glossary/pull/2814

Therefore, I need to update config.yaml in `cncf/people`