### PR TITLE
Fix Cmierly access to k8s-conformance repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -596,7 +596,7 @@ repositories:
       Riaankl: admin
       hh: admin
       cncf-ci: admin
-      cmierly: maintain
+      Cmierly: maintain
     name: k8s-conformance
   - external_collaborators:
       AudMonte01: admin


### PR DESCRIPTION
@taylorwaggoner, values must be valid GitHub usernames (case sensitive)