### PR TITLE
update TAG ENV team and add TAG ENV chairs team

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -826,15 +826,12 @@ repositories:
   - external_collaborators:
       amye: admin
       caniszczyk: admin
-      caradelia: maintain
-      catblade: admin
-      guidemetothemoon: maintain
-      leonardpahlke: admin
-      mkorbi: admin
       nate-double-u: admin
-      nikimanoledaki: maintain
       chalin: maintain
     name: tag-env-sustainability
+    teams:
+      tag-env-chairs: admin
+      tag-env-sustainability: maintain
     settings:
       has_wiki: true
   - external_collaborators:
@@ -1159,17 +1156,25 @@ teams:
       - onlydole
     displayName: CNCF End Users
     secret: false
+  - name: tag-env-chairs
+    maintainers:
+      - leonardpahlke
+    members:
+      - catblade
+      - mkorbi
   - name: tag-env-sustainability
     maintainers:
       - leonardpahlke
     members:
-      - caradelia
+      - AntonioDiTuri
       - catblade
+      - claire-fletcher
       - guidemetothemoon
       - mkorbi
       - nikimanoledaki
       - patricia-cahill
-      - AntonioDiTuri
+      - rossf7
+      - savitharaghunathan
   - name: tag-contributor-strategy
     formation:
       - tcs-maintainers


### PR DESCRIPTION
Updates the TAG ENV team. Removes Cara as she is stepping down as TL and WG Chair for Comms. Antonio and Ross are added as WG Green Reviews Chair / TL. Claire and Savithara are added as WG Comms TLs. 