### PR TITLE
Update tag-security collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -878,6 +878,7 @@ repositories:
       dshaw: write
       jkjell: write
       justincormack: write
+      lirantal: read
       lumjjb: write
       mlieberman85: write
       mnm678: admin


### PR DESCRIPTION
Update TAG Security collaborators according to https://github.com/cncf/tag-security/pull/1232