### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -502,7 +502,7 @@ repositories:
       meryem-ldn: read
       mitul3737: write
       Okabe-Junya: write
-      pichuang: write
+      tico88612: write
       raelga: write
       ramrodo: write
       same7ammar: write


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently removed existing localization approvers and added new approvers to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/2960

Add new approvers for zh-tw branch based on a requested by the localization team.
- @tico88612 

Step down approvers for zh-tw branch based on a requested by the localization team.
- @pichuang


We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.