### PR TITLE
Add nancy to TAG ENV list

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1175,6 +1175,7 @@ teams:
       - claire-fletcher
       - guidemetothemoon
       - mkorbi
+      - Nancy-Chauhan
       - nikimanoledaki
       - patricia-cahill
       - rossf7


### PR DESCRIPTION
This PR adds @Nancy-Chauhan to the TAG ENV GitHub group. 