### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -516,7 +516,7 @@ repositories:
       ydFu: write
       yunkon-kim: write
       aliok: write
-      halil-bugol: write
+      symys: write
       rwxdash: write
       eminalemdar: write
       shurup: write


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently removed existing localization approvers and added new approvers to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/3016

Add new approvers for dev-tr branch based on a request from the localization team.
- @symys 

Step down approvers for dev-tr branch based on a request from the localization team.
- @halil-bugol


We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.