### PR TITLE
Add write permissions for zanetworker in tag-runtime

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -865,6 +865,7 @@ repositories:
       raravena80: admin
       k82cn: admin
       kad: admin
+      zanetworker: write
     name: tag-runtime
   - external_collaborators:
       JustinCappos: write


### PR DESCRIPTION
To be able to contribute and help manage initiatives for the CNAI working group, I was asked to add `write` permissions (cc @raravena80). For example, to be able to contribute to https://github.com/orgs/cncf/projects/38/views/1 