### PR TITLE
Remove non-existent account from permissions file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,7 +172,6 @@ repositories:
       has_wiki: true
   - external_collaborators:
       Snergster: read
-      bvera: read
       denverwilliams: admin
       edwarnicke: write
       electrocucaracha: write


### PR DESCRIPTION
The account `bvera` does no longer exist on GitHub, so every time CLOWarden tries to set its permissions, an error is raised.