### PR TITLE
location fixed

### DIFF
--- a/people.json
+++ b/people.json
@@ -9382,7 +9382,7 @@
       "bio": "<p>I am Süleyman from Türkiye, deeply involved in DevOps with a strong focus on Kubernetes. As a Co-Founder at RNG Technology GmbH, we facilitate comprehensive infrastructure solutions for businesses across Türkiye, Germany and Europe.</p>",
       "company": "RNG Technology GmbH",
       "pronouns": "He/Him",
-      "location": "Istanbul, Türkiye",
+      "location": "Istanbul, Turkey",
       "linkedin": "https://www.linkedin.com/in/suleyman-kutukoglu/",
       "twitter": "",
       "github": "https://github.com/suleyman-kutukoglu",


### PR DESCRIPTION
I changed my location from Türkiye to Turkey.

Globally Turkey country now recognise as Türkiye but on Kubestronaut page I can't see Türkiye location.

So I changed my location to Turkey.