### PR TITLE
Update cncf/glossary external_collaborators

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -477,7 +477,7 @@ repositories:
       edsoncelio: write
       electrocucaracha: write
       fsbaraglia: write
-      fydrah: write
+      seb-835: write
       hanyuancheung: write
       huats: write
       iamNoah1: admin


### PR DESCRIPTION
Hello folks !
I am one of the maintainers of the https://github.com/cncf/glossary

We've recently removed existing localization approvers and added new approvers to the cncf/glossary repository
 - Based on https://github.com/cncf/glossary/pull/3075

Add new approvers for dev-tr branch based on a request from the localization team.
- @seb-835

Step down approvers for dev-tr branch based on a request from the localization team.
- @fydrah


We need to update config.yaml in cncf/people in order to follow the CNCF Sheriff bot.