### PR TITLE
fix: use proper image for Nathanael Liechti kubestronaut

### DIFF
--- a/people.json
+++ b/people.json
@@ -8643,7 +8643,7 @@
          "Kubestronaut"
       ],
       "slack_id": "",
-      "image": "phippy.jpg"
+      "image": "nathanael-liechti.jpg"
    },
    {
       "name": "Nick Jones",


### PR DESCRIPTION
Fixes the image link added in #512 