### PR TITLE
Adds Nate as an admin to cncf/people

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -676,11 +676,12 @@ repositories:
   - name: parallel-netlify-builds
     settings:
       has_wiki: true
-  - external_collaborators:
+  - name: people
+    external_collaborators:
       idvoretskyi: maintain
       thetwopct: maintain
       huats: maintain
-    name: people
+      nate-double-u: admin
     settings:
       has_wiki: true
   - external_collaborators:


### PR DESCRIPTION
Adds @nate-double-u as an admin to this repo.

I re-ordered the entries so that `name: people `appears before `external_collaborators`