### PR TITLE
Add `@Dindihub` as techdocs collaborator - LFX 24T2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -885,7 +885,7 @@ repositories:
       thisisobate: maintain
       psgustafson: triage # Expert Support
       dwelsch-esi: triage # Expert Support
-      jbogarthyde: triage # Expert Support
+      Dindihub: read # https://github.com/cncf/techdocs/issues/267 - LFX 24T2
     name: techdocs
   - external_collaborators:
       dabernie: read


### PR DESCRIPTION
- Adds `@Dindihub` as techdocs collaborator - LFX 24T2
- Drops `jbogarthyde`, who I believe is no longer working on the techdocs

cc @nate-double-u