### PR TITLE
Add team for end user TAB

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1039,6 +1039,16 @@ teams:
       - jeefy
       - idvoretskyi
       - krook
+  - name: cncf-tab
+    maintainers:
+      - mrbobbytables
+      - onlydole
+    members:
+      - aparna-subramanian
+      - dzolotusky
+      - hblixt
+      - kgamanji
+      - rochaporto
   - name: cncf-tech-docs
     maintainers:
       - nate-double-u


### PR DESCRIPTION
Team members are currently the only ones that are a member of the CNCF org. 
It'll be updated later once the other members have accepted an org invite.