### PR TITLE
Update list of TLs in TAG Runtime access config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -849,6 +849,7 @@ repositories:
       kad: admin
       zanetworker: write
       ronaldpetty: write
+      rajaskakodkar: admin
     name: tag-runtime
   - external_collaborators:
       JustinCappos: write


### PR DESCRIPTION
Adds Rajas (TL of TAG Runtime) to the access config of TAG Runtime

ref: https://github.com/cncf/tag-runtime/tree/main/README.md#tag-tech-leads

cc @raravena80 