### PR TITLE
Create toc-private repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -909,6 +909,11 @@ repositories:
     teams:
       cncf-toc: write
       cncf-projects: admin
+  - name: toc-private
+    teams:
+      cncf-toc: write
+      cncf-projects: admin
+    visibility: private
   - teams:
       landscapers: admin
     name: trailmap


### PR DESCRIPTION
The private repo will be used as an extension of the toc private board so that items from the board can be converted to issue for further discussion and assignment.