### PR TITLE
fix: correct LinkedIn URL for Vander Nunes

### DIFF
--- a/people.json
+++ b/people.json
@@ -18544,11 +18544,11 @@
    },
    {
       "name": "Vander Nunes",
-      "bio": "<p>I am passionate about cloud-native technologies and DevOps, and I lead Nuno Cloud, focusing on helping businesses optimize their cloud infrastructure. I enjoy sharing my expertise through Meetups, where I discuss Kubernetes, cloud automation, and best practices in the industry. With a growing emphasis on KSPM, I am also committed to helping organizations strengthen their security in Kubernetes environments. To learn more about my work, you can reach out to me at https://www.linkedin.com/in/vandervnr/</p>",
+      "bio": "<p>I am passionate about cloud-native technologies and DevOps, and I lead Nuno Cloud, focusing on helping businesses optimize their cloud infrastructure. I enjoy sharing my expertise through Meetups, where I discuss Kubernetes, cloud automation, and best practices in the industry. With a growing emphasis on KSPM, I am also committed to helping organizations strengthen their security in Kubernetes environments. To learn more about my work, you can reach out to me at vander@linux.com</p>",
       "company": "Nuno Cloud",
       "pronouns": "He/Him",
       "location": "São Paulo, Brazil",
-      "linkedin": "https://www.linkedin.com/in/http://linkedin.com/in/vandervnr/",
+      "linkedin": "https://www.linkedin.com/in/vandervnr/",
       "twitter": "https://x.com/nuno_cloud",
       "github": "https://github.com/vandernunes",
       "wechat": "",


### PR DESCRIPTION
This PR fixes the incorrect LinkedIn URL in the people.json file for Vander Nunes.
The previous URL had an extra prefix, causing a broken link. This update corrects it to ensure the link is functional.