### PR TITLE
Remove max as chair from TAG ENV

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1170,7 +1170,6 @@ teams:
       - leonardpahlke
     members:
       - catblade
-      - mkorbi
   - name: tag-env-sustainability
     maintainers:
       - leonardpahlke
@@ -1179,7 +1178,6 @@ teams:
       - catblade
       - claire-fletcher
       - guidemetothemoon
-      - mkorbi
       - Nancy-Chauhan
       - nikimanoledaki
       - patricia-cahill


### PR DESCRIPTION
This PR updates the member list of TAG ENV

ref tracking issue: https://github.com/cncf/tag-env-sustainability/issues/531
ref issue max stepping down: https://github.com/cncf/tag-env-sustainability/pull/527

cc @riaankleinhans 