### PR TITLE
Update tag env member list oct 2024

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1179,14 +1179,13 @@ teams:
       - catblade
       - claire-fletcher
       - guidemetothemoon
+      - locomundo
       - Nancy-Chauhan
       - nikimanoledaki
-      - patricia-cahill
       - rossf7
       - saiyam1814
       - savitharaghunathan
-      - xamebax
-      - JacobValdemar
+      - vallss
   - name: tag-contributor-strategy
     formation:
       - tcs-maintainers


### PR DESCRIPTION
This PR updates the list of members in TAG Environmental Sustainability

Remove:
- patricia-cahill: Patricia stepped down as WG Comms Chair earlier this year. See https://github.com/cncf/tag-env-sustainability/pull/503
- xamebax & JacobValdemar: both lead a project which has been closed. See project archival issue https://github.com/cncf/tag-env-sustainability/issues/500 (see original tracking issue https://github.com/cncf/tag-env-sustainability/issues/347) 

Add:
- vallss: New WG Comms TL (see issue https://github.com/cncf/tag-env-sustainability/issues/520)
- locomundo: New WG Green Reviews TL (see issue: https://github.com/cncf/tag-env-sustainability/issues/513)


cc @RobertKielty 