### PR TITLE
TAG ENV, update alessandro's and Kristina's roles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1162,10 +1162,12 @@ teams:
       - leonardpahlke
     members:
       - catblade
+      - guidemetothemoon
   - name: tag-env-sustainability
     maintainers:
       - leonardpahlke
     members:
+      - ams0
       - AntonioDiTuri
       - catblade
       - claire-fletcher


### PR DESCRIPTION
* Krisitna Devochko onboarding issue: https://github.com/cncf/tag-env-sustainability/issues/563
* Alessandro Vozza onboarding issue: https://github.com/cncf/tag-env-sustainability/issues/564