### PR TITLE
Rename enduser and tab repos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -397,15 +397,14 @@ repositories:
     visibility: private
   - external_collaborators:
       Swil78: admin
-      idvoretskyi: write
       onlydole: admin
       taylorwaggoner: admin
-    name: enduser
+    name: enduser-private
     visibility: private
     teams:
       cncf-end-users: write
-      cncf-tab: admin
-  - name: enduser-public
+      cncf-tab: write
+      cncf-projects: admin
   - name: evolution-of-cloud-native
     visibility: private
     external_collaborators:
@@ -791,9 +790,22 @@ repositories:
     settings:
       has_wiki: true
   - name: tab
+    visibility: public
     teams:
       cncf-tab: write
       cncf-projects: admin
+    external_collaborators:
+      Swil78: admin
+      onlydole: admin
+      taylorwaggoner: admin
+  - name: tab-private
+    teams:
+      cncf-tab: write
+      cncf-projects: admin
+    external_collaborators:
+      Swil78: admin
+      onlydole: admin
+      taylorwaggoner: admin
     visibility: private
   - external_collaborators:
       kgamanji: admin


### PR DESCRIPTION
The end user repos are being restructured to more closely mirror the TOC.

A summary of changes:
- cncf/tab -> cncf/tab-private - used for private discussions, meetings etc
- cncf/enduser-public -> cncf/tab - used for public facing issues, policies, discussions, meetings
- cncf/enduser -> cncf/enduser-private - end user members only items, discussions etc
