### PR TITLE
Add Kubermatic to k8s-conformance repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -569,6 +569,9 @@ repositories:
       heyste: admin
       cncf-ci: admin
       Cmierly: maintain
+      koksay: admin
+      mfahlandt: admin
+      xmudrii: admin
     name: k8s-conformance
   - external_collaborators:
       AudMonte01: admin


### PR DESCRIPTION
Admin access to update the GitHub action on `k8s-conformance` repo when there is a new verify-conformance version.

Fyi, @xmudrii @mfahlandt 

/cc @jeefy