### PR TITLE
add pacoxu and windsonsea to glossary collaborator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -523,6 +523,8 @@ repositories:
       mboukhalfa: write
       seifrajhi: write
       adowair: write
+      pacoxu: write
+      windsonsea: write
     name: glossary
   - external_collaborators:
       halcyondude: admin


### PR DESCRIPTION
I want to submit a sync PR from zh to main and failed for not being a https://github.com/cncf/glossary/issues/3145.

See https://github.com/cncf/glossary/pull/3038 which is my original PR.

/cc @cjyabraham