### PR TITLE
Update information for Marvin Beckers

### DIFF
--- a/people.json
+++ b/people.json
@@ -15644,13 +15644,16 @@
    },
    {
       "name": "Marvin Beckers",
-      "bio": "<p>Marvin is a Team Lead and Senior Software Engineer at Kubermatic. He initially started out in IT operations and became fascinated with Kubernetes in 2018, eventually transitioning into software development. Today, he is a public speaker, a maintainer for the CNCF project kcp and an organiser for Cloud Native Aachen. His personal blog is available at https://marvin.beckers.dev.</p>",
+      "bio": "<p>Marvin is a Team Lead and Senior Software Engineer at Kubermatic. He initially started out in IT operations and became fascinated with Kubernetes in 2018, eventually transitioning into software development. Today, he is a public speaker, a maintainer for the CNCF project kcp and an organiser for Cloud Native Aachen.</p>",
       "company": "Kubermatic",
       "pronouns": "He/Him",
       "location": "Aachen, Germany",
-      "twitter": "https://twitter.com/",
+      "bluesky": "https://bsky.app/profile/marvin.beckers.dev",
+      "linkedin": "https://www.linkedin.com/in/marvinbeckers/",
+      "twitter": "",
       "github": "https://github.com/embik",
-      "slack": "MarvinBeckers",
+      "website": "https://marvin.beckers.dev",
+      "slack_id": "MarvinBeckers",
       "category": [
          "Ambassadors"
       ],


### PR DESCRIPTION
Hey folks! 👋🏻 

I would like to add some more information to my profile, so here is a PR that updates things and puts them a bit more into standard (I think the personal website in the bio is kind of unusual, and there's a field for it anyway).

I'm a little confused about `slack` vs `slack_id`. Many entries have the `slack` field, but `slack_id` seems to be the right one according to `schema.json`. If this correction is not accurate, please let me know and I will drop it from the commit.