### PR TITLE
Add slack and github to Florian Feldmann's profile

### DIFF
--- a/people.json
+++ b/people.json
@@ -8961,14 +8961,14 @@
         "location": "Kamen, NRW, Germany",
         "linkedin": "https://www.linkedin.com/in/florian-feldmann/",
         "twitter": "",
-        "github": "",
+        "github": "https://github.com/flofeld",
         "wechat": "",
         "website": "https://flo.rest",
         "youtube": "",
         "category": [
             "Kubestronaut"
         ],
-        "slack_id": "",
+        "slack_id": "U08C2AC8M2B",
         "image": "florian-feldmann.jpg"
     },
     {


### PR DESCRIPTION
I added my github and my slack id to get access to the private kubestronaut channel.