### PR TITLE
Fix CLOWarden warnings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -425,7 +425,6 @@ repositories:
   - external_collaborators:
       taylorwaggoner: admin
       joannalee333: admin
-      Cmierly: write
       nate-double-u: write
     name: foundation
   - external_collaborators:
@@ -566,7 +565,6 @@ repositories:
       hh: admin
       heyste: admin
       cncf-ci: admin
-      Cmierly: maintain
       koksay: admin
       mfahlandt: admin
       xmudrii: admin
@@ -998,7 +996,6 @@ repositories:
       catinahat85: write
       castrojo: write
       chalin: write
-      Cmierly: write
       cjyabraham: admin
       ctorbin: write
       cynthia-sg: write
@@ -1131,8 +1128,7 @@ teams:
     maintainers:
       - jeefy
   - name: cncf-projects
-    members:
-      - Cmierly
+    members: []
     maintainers:
       - jeefy
     displayName: CNCF Projects Team


### PR DESCRIPTION
It looks like @Cmierly has removed herself from the CNCF org. Given that she's still in the config file, CLOWarden is trying to invite her back (she cancelled the new invitations). This PR removes her from the configuration file so that she doesn't receive any more invitations.

/cc @RobertKielty @jeefy