### PR TITLE
Update company affiliation for Noam Strauss to Splunk

### DIFF
--- a/people.json
+++ b/people.json
@@ -26755,7 +26755,7 @@
     {
         "name": "Noam Strauss",
         "bio": "<p>I’m a DevOps/Site Reliability Engineer who enjoys digging into complex systems, solving real-world problems, and continuously learning new things. I’m especially drawn to the ever-evolving world of cloud-native technologies and love the challenge of making infrastructure more efficient, scalable, and reliable.</p>",
-        "company": "Aqua Secuirty",
+        "company": "Splunk",
         "pronouns": "",
         "location": "Providence, RI, United States",
         "linkedin": "https://www.linkedin.com/in/noam-strauss",


### PR DESCRIPTION
This pull request updates the company field for Noam Strauss in the people.json file to reflect the current company affiliation as "Splunk (a Cisco company)".