### PR TITLE
Add Glossary TR l10n approvers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -468,9 +468,9 @@ repositories:
       ydFu: write
       yunkon-kim: write
       aliok: write
-      symys: write
-      rwxdash: write
-      eminalemdar: write
+      canogluonur: write
+      mertssmnoglu: write
+      Alianait: write
       shurup: write
       kirkonru: write
       hwchiu: write


### PR DESCRIPTION
Based on https://github.com/cncf/glossary/pull/3530

Replacing @symys @rwxdash @eminalemdar with @canogluonur @mertssmnoglu @Alianait as they are the new Turkish localization approvers for the CNCF Glossary.