### PR TITLE
Move AI Conformance Repo to Public

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ repositories:
       fedebongio: maintain
       jagosan: maintain
       janetkuo: maintain
-    visibility: private
+    visibility: public
   - name: ambassadors
   - external_collaborators:
       stevenphtan: admin


### PR DESCRIPTION
As it was shared in KubeCon Japan, the repo is still not accessible - this will fix this