### PR TITLE
Update Jooho Lee's github link in people.json

### DIFF
--- a/people.json
+++ b/people.json
@@ -19172,7 +19172,7 @@
         "location": "Seoul, South Korea",
         "linkedin": "https://www.linkedin.com/in/joo-ho-lee",
         "twitter": "",
-        "github": "https://github.com/jholee",
+        "github": "https://github.com/etamong",
         "wechat": "",
         "website": "",
         "youtube": "",


### PR DESCRIPTION
My GitHub username was changed from `jholee` to `etamong`.

Previous related PR: https://github.com/cncf/people/pull/983