### PR TITLE
Add toc-voters to toc repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -799,6 +799,7 @@ repositories:
   - name: toc
     teams:
       cncf-toc: write
+      cncf-toc-voters: write
       cncf-projects: admin
       tag-developer-experience-leads: write
       tag-infrastructure-leads: write


### PR DESCRIPTION
need to add cncf-toc-voters in addition to cncf-toc for codeowners config