### PR TITLE
docs: update Calum Murray's company affiliation

### DIFF
--- a/people.json
+++ b/people.json
@@ -8133,7 +8133,7 @@
     {
         "name": "Calum Murray",
         "bio": "<p>I'm a Knative Eventing Maintainer and UX Working Group Lead. I co-founded the University of Toronto Open Source Students, where I help university students contribute to open source projects, such as Knative and CloudEvents.</p>",
-        "company": "University of Toronto",
+        "company": "Red Hat",
         "pronouns": "He/Him",
         "location": "Toronto, Canada",
         "twitter": "",


### PR DESCRIPTION
I started working at Red Hat in June, and realized that I hadn't updated my ambassador profile