### PR TITLE
Update Alvaro Navarro company information to Latam Airlines

### DIFF
--- a/people.json
+++ b/people.json
@@ -2849,8 +2849,8 @@
     },
     {
         "name": "Alvaro Navarro",
-        "bio": "<p>I’m a Platform Engineer from Chile with a strong focus on Kubernetes, observability, and DevSecOps. I’ve worked on projects involving Grafana, InfluxDB, Docker, and cloud infrastructure across AWS and Azure. I’ve contributed to initiatives that improve system monitoring, security, and deployment automation. I’m passionate about cloud-native technologies and love sharing knowledge through meetups, talks, and hands-on workshops.</p>",
-        "company": "Darts TI",
+        "bio": "<p>I’m a Platform Engineer from Chile with a strong focus on Kubernetes, observability, and DevSecOps. I’ve worked on projects involving Grafana, InfluxDB, Docker, and cloud infrastructure across GCP and Azure. I’ve contributed to initiatives that improve system monitoring, security, and deployment automation. I’m passionate about cloud-native technologies and love sharing knowledge through meetups, talks, and hands-on workshops.</p>",
+        "company": "Latam Airlines",
         "pronouns": "He/Him",
         "location": "Puente Alto, Región Metropolitana, Chile",
         "linkedin": "https://www.linkedin.com/in/alvaronicolasnavarrocastro/",


### PR DESCRIPTION
Updated company information for Alvaro Navarro:
- Company: Darts TI → Latam Airlines
- Bio: Updated cloud infrastructure experience from AWS to GCP