### PR TITLE
Remove @matteobisi from cncf/glossary write access

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -449,7 +449,6 @@ repositories:
       kaitoii11: write
       krol3: write
       naonishijima: write
-      matteobisi: write
       meryem-ldn: read
       mitul3737: write
       Okabe-Junya: admin


### PR DESCRIPTION
Removed @matteobisi from the list of users with write access to cncf/glossary repo.

Ref:
- https://cloud-native.slack.com/archives/C02M9HPU9T9/p1762159540893009?thread_ts=1743938902.619549&cid=C02M9HPU9T9
- https://github.com/cncf/glossary/pull/3588
