### PR TITLE
Rename ai-conformance to k8s-ai-conformance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ repositories:
   - teams:
       cncf-projects: admin
     name: migrate-maintainers
-  - name: ai-conformance
+  - name: k8s-ai-conformance
     external_collaborators:
       castrojo: admin
       jeefy: admin


### PR DESCRIPTION
Rename of the Repo as per GB decision https://www.cncf.io/wp-content/uploads/2025/10/2025-Oct-27-Resolutions-CNCF-Governing-Board.pdf