### PR TITLE
Update external collaborators for triage on KCD Repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -534,11 +534,13 @@ repositories:
   - external_collaborators:
       AudMonte01: admin
       hspease99: maintain
-      CsatariGergely: triage
-      maci3jka: triage
-      ramrodo: write
-      senthilrch: write
-      wrkode: triage
+      satyampsoni: triage
+      Saloni1814: triage
+      parraletz: triage
+      hazzim: triage
+      electrocucaracha: triage
+      abebars: triage
+      mageshwaransekar: triage
     name: kubernetes-community-days
   # These Landscape forks need to stop
   # But this is a quick fix to unblock Sheriff


### PR DESCRIPTION
Removed several external collaborators and added new ones with triage roles for 2026 KCD issue tracking.