### PR TITLE
Add cncf-automation-bot to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -685,6 +685,7 @@ repositories:
       tag-security-compliance-leads: write
       tag-workloads-foundation-leads: write
     external_collaborators:
+      cncf-automation-bot: write
       joshgav: write
     name: sandbox
     settings:
@@ -800,6 +801,8 @@ repositories:
       tag-security-compliance-leads: write
       tag-workloads-foundation-leads: write
       toc-project-reviews-subproject: write
+    external_collaborators:
+      cncf-automation-bot: write
   - name: toc-private
     teams:
       cncf-tab: write


### PR DESCRIPTION
This would be used for running the 3,6,9,12 month time checks on the Sandbox on-boarding issues.