### PR TITLE
Fix LinkedIn URL for Joao Kauling Neto

### DIFF
--- a/people.json
+++ b/people.json
@@ -29059,7 +29059,7 @@
         "company": "Volkswagen",
         "pronouns": "He/Him",
         "location": "Curitiba, Brazil",
-        "linkedin": "https://www.linkedin.com/in/joaokauling@gmail.com",
+        "linkedin": "https://www.linkedin.com/in/joaokaulingneto",
         "twitter": "",
         "github": "",
         "wechat": "",


### PR DESCRIPTION
Updating my CNCF People (Kubestronaut) profile LinkedIn URL.