### PR TITLE
Add external collaborators to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ repositories:
     name: migrate-maintainers
   - external_collaborators:
       AudMonte01: admin
-  - name: ambassadors
+    name: ambassadors
   - external_collaborators:
       stevenphtan: admin
     name: api


### PR DESCRIPTION
added Audra as Admin to ambassadors repo, and two Lima, Peru organizers as triage for KCD repo.