### PR TITLE
updates public-sector-user-group admins

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -680,10 +680,8 @@ repositories:
     name: radar
   - name: public-sector-user-group
     external_collaborators:
-      AlanHohn: admin
-      idunbarh: admin
       djmoch: admin
-      sfb103: admin
+      wcrum: admin
     settings:
       has_wiki: true
   - external_collaborators:


### PR DESCRIPTION
As of 22 January, wcrum has been elected co-chair. The others are removed as they no longer are able to participate in the user group's work.