### PR TITLE
Add staff team configuration to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -730,6 +730,12 @@ repositories:
     name: site-boilerplate
     settings:
       has_wiki: true
+  - name: staff
+    teams:
+      cncf-enduser-staff-core: write
+      cncf-projects: admin
+    external_collaborators:
+      cncf-automation-bot: write
   - external_collaborators:
       flanets: triage
       idvoretskyi: admin


### PR DESCRIPTION
- Introduced a new team 'staff' with specific permissions for 'cncf-enduser-staff-core' and 'cncf-projects'.
- Added 'cncf-automation-bot' as an external collaborator with write access.