### PR TITLE
fix: remove Will Musgrave company affiliation

### DIFF
--- a/people.json
+++ b/people.json
@@ -65658,7 +65658,7 @@
     },
     {
         "name": "Will Musgrave",
-        "bio": "<p>Will is a data architect that uses cloud native technologies to create secure, highly available and resilient systems that deliver great customer experiences while minimizing cloud costs wherever possible. He has industry experience developing software in a variety of disciplines, including medical physics, sports analytics, e-mental health and supply chain/logistics. He has a keen interest in CNCF technologies (including Kubernetes, Istio, Cilium and Flux) and strives to stay on top of the latest technological trends and contribute to the CNCF community. In his spare time, Will enjoys soccer, running, cooking and coffee.</p>",
+        "bio": "<p>Will is a data architect that uses cloud native technologies to create secure, highly available and resilient systems that deliver great customer experiences while minimizing cloud costs wherever possible. He has industry experience developing software in a variety of disciplines, including medical physics, sports analytics, e-mental health and supply chain/logistics. He has a keen interest in CNCF technologies (including Kubernetes, Istio and Cilium) and strives to stay on top of the latest technological trends and contribute to the CNCF community. In his spare time, Will enjoys soccer, running, cooking and coffee.</p>",
         "company": "",
         "pronouns": "He/Him",
         "location": "Halifax, Nova Scotia, Canada",


### PR DESCRIPTION
In this PR, I remove my company affiliation as I am no longer employed at Everstream Analytics.

Please let me know if there is anything else that is required on my end.

Thank you,
Will