### PR TITLE
Fix Roman Rabodzei's entry: Fixed name and bio

### DIFF
--- a/people.json
+++ b/people.json
@@ -56029,8 +56029,8 @@
         "image": "romain-tixier.jpg"
     },
     {
-        "name": "Roman",
-        "bio": "<p>I’m a Principal Cloud & DevOps Engineer with over 17 years of hands-on experience in infrastructure and cloud platforms. I specialize in Kubernetes and CNCF technologies, with a strong focus on Azure, CI/CD automation, and cloud security. I enjoy designing reliable, production-grade platforms and continuously improving operational excellence. Passionate about learning, sharing knowledge, and contributing to the cloud-native community.</p>",
+        "name": "Roman Rabodzei",
+        "bio": "<p>Principal Cloud & DevOps Engineer with over 17 years of hands-on experience in infrastructure and cloud platforms. I specialize in Kubernetes and CNCF technologies, with a strong focus on Azure, CI/CD automation, and cloud security. I enjoy designing reliable, production-grade platforms and continuously improving operational excellence. Passionate about learning, sharing knowledge, and contributing to the cloud-native community.</p>",
         "company": "rinf.tech",
         "pronouns": "He/Him",
         "location": "Wroclaw, Poland",


### PR DESCRIPTION
This pull request makes a minor update to the `people.json` file, correcting the full name for one team member.

* Updated the `name` field from `"Roman"` to `"Roman Rabodzei"`
* Shortened bio