### PR TITLE
Modernize CI: harden workflow, replace JSON validator, add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,13 +2,19 @@ name: Validate JSONs
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   verify-json-validation:
     runs-on: oracle-2cpu-8gb-x86-64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '>= 3.14'
+          pip-install: check-jsonschema
       - name: Validate JSON
-        uses: docker://orrosenblatt/validate-json-action:latest
-        env:
-          INPUT_SCHEMA: /schema.json
-          INPUT_JSONS: /people.json
+        run: check-jsonschema --schemafile schema.json people.json

--- a/schema.json
+++ b/schema.json
@@ -18,7 +18,7 @@
             "youtube":   {"anyOf": [ { "maxLength": 0 }, {"type": "string", "format": "uri", "default": "null"} ] },
             "priority":  {"anyOf": [ { "maxLength": 0 }, { "type": "number"  } ] },
             "image":     {"type": "string"},
-            "email":     {"type": "string", "pattern": "^[^\\s@]+\\![^\\s@]+\\.[^\\s@]+$"},
+            "email":     {"type": "string", "pattern": "^[^\\s@]+![^\\s@]+\\.[^\\s@]+$"},
             "slack_id":  {"type": "string"},
             "category": {
                 "type": "array",


### PR DESCRIPTION
## Summary

- **Harden GitHub Actions workflow**: Add `permissions: contents: read` (least-privilege), upgrade `actions/checkout` to v6 with `persist-credentials: false`
- **Replace JSON validator**: Swap the unmaintained `docker://orrosenblatt/validate-json-action:latest` container for [`check-jsonschema`](https://github.com/python-jsonschema/check-jsonschema) (from the `python-jsonschema` org — maintainers of the reference Python JSON Schema implementation)
- **Add dependabot config**: Automated weekly PRs to keep GitHub Actions versions current

## Schema change detail

The email regex pattern in `schema.json` contained `\!` — a backslash-escaped exclamation mark. The `!` character is not a special regex character and does not need escaping. Per ECMA-262 (the JavaScript regex standard), `\!` is technically an invalid escape sequence.

The old validator (AJV, via the Docker action) was lenient about this and silently treated `\!` as `!`. `check-jsonschema` correctly rejects the invalid escape per the spec. The fix is simply removing the unnecessary backslash: `\!` → `!`.

**There is no behavioral change** — both `\!` (where tolerated) and `!` match the literal `!` character. The set of valid/invalid email strings matched by the pattern is identical before and after this change.

```diff
- "pattern": "^[^\\s@]+\\![^\\s@]+\\.[^\\s@]+$"
+ "pattern": "^[^\\s@]+![^\\s@]+\\.[^\\s@]+$"
```

## Verification

- `check-jsonschema --schemafile schema.json people.json` passes locally against the current `people.json`

## Test plan

- [x] CI workflow runs successfully on this PR (the workflow itself validates the schema)
- [x] Review `validate.yml` for correctness
- [x] Review `schema.json` pattern change
- [x] Review `dependabot.yml` config