### PR TITLE
Update bio for Tatiana Mikhaleva

### DIFF
--- a/people.json
+++ b/people.json
@@ -69501,10 +69501,10 @@
     },
     {
         "name": "Tatiana Mikhaleva",
-        "bio": "Tatiana Mikhaleva is a <b>Docker Captain</b>, <b>GitKraken Ambassador</b>, <b>Notion Ambassador</b>, and <b>DevOps engineer</b> — the creator of <a href='https://devops.pink/'>DevOps.Pink</a>, a corner of the internet where cloud automation meets clarity, community, and a touch of pink rebellion.<br><br>She has years of experience working with <b>AWS</b>, <b>Azure</b>, <b>Kubernetes</b>, <b>Terraform</b>, and <b>Docker</b>, focusing on transforming messy, fragile systems into clean, automated, and reliable infrastructures that give engineers back their time and sanity.<br><br>Through DevOps.Pink, Tatiana has built a vibrant community that promotes inclusive, real-world DevOps learning — breaking down barriers and amplifying voices, especially women in tech. Her mission is to make DevOps <i>exciting instead of exhausting</i>, showing that cloud and containers can be a superpower.<br><br>Featured by Docker on their official YouTube channel, Tatiana shares practical, empowering insights through talks, tutorials, and creative content that makes tech feel human, approachable, and even fun.",
-        "company": "DevOps.Pink / Docker Captain / GitKraken Ambassador / Notion Ambassador",
+        "bio": "Tatiana Mikhaleva is an independent Developer Advocate and founder of <a href='https://devops.pink/'>DevOps.Pink</a>. A <b>CNCF Ambassador</b>, <b>Docker Captain</b>, and <b>IBM Champion</b>, she holds ambassador roles across eight developer tooling programs in total.<br><br>Through DevOps.Pink, Tatiana covers <b>Docker</b>, <b>Kubernetes</b>, and the agentic-AI stack for tens of thousands of engineers worldwide. Her work focuses on making cloud-native tools accessible through walkthroughs, demos, and production-ready code — with a particular emphasis on shipping close to release cycles so the community can learn alongside the newest features.<br><br>She runs the Toronto Cloud-Native & Container AI community, speaks across vendor channels on cloud-native tooling, container security, and AI-augmented development, and contributes editorial work on cloud-native developer experience.<br><br>A journalist by training, Tatiana brings editorial rigor to technical education, at the intersection of cloud-native practice and the agentic-AI era.",
+        "company": "Founder & Senior Developer Advocate at DevOps.Pink",
         "pronouns": "She/Her",
-        "location": "Toronto, Canada",
+        "location": "Toronto, Ontario, Canada",
         "linkedin": "https://www.linkedin.com/in/DevOpsPink/",
         "twitter": "https://x.com/DevOpsPink",
         "github": "https://github.com/DevOpsPink",
@@ -69513,18 +69513,20 @@
         "youtube": "https://www.youtube.com/@DevOpsPink",
         "priority": 10,
         "languages": [
-            "English"
+            "English",
+            "Russian",
+            "Czech",
+            "Romanian"
         ],
         "projects": [
-            "docker",
             "kubernetes",
-            "cncf",
-            "devops"
+            "helm",
+            "prometheus"
         ],
         "category": [
             "Ambassadors"
         ],
-        "email": "ask!devops.pink",
+        "email": "connect!devops.pink",
         "slack_id": "",
         "image": "tatiana-mikhaleva.jpg"
     },


### PR DESCRIPTION
Updates:
- Role title updated to Founder & Senior Developer Advocate
- Bio rewritten to reflect current work: Docker Early-Access beta programs, Toronto Cloud-Native & Container AI community, editorial work, and agentic-AI focus
- Languages expanded (added Russian, Czech, Romanian)
- Location updated to Google Maps-readable format (Toronto, Ontario, Canada)
- CNCF projects updated to reflect actual content coverage
- Removed Docker from projects list (not a CNCF project)
- Company field simplified to current title