### PR TITLE
Fix CLOWarden warnings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -483,7 +483,6 @@ repositories:
       adowair: write
       ntheanh201: write
       thuanpham582002: write
-      thaomike: write
       xehrad: write
       Parsabz: write
     name: glossary


### PR DESCRIPTION
Remove thaomike from glossary permissions