### PR TITLE
Luna geographical location update

### DIFF
--- a/people.json
+++ b/people.json
@@ -54953,7 +54953,7 @@
         "bio": "<p>Kubestronaut, Multi-cloud(AWS/GCP) Architect </p>",
         "company": "",
         "pronouns": "She/Her",
-        "location": "Japan, Tokyo",
+        "location": "Tokyo, Japan",
         "linkedin": "",
         "twitter": "",
         "github": "https://github.com/rikuroubai",


### PR DESCRIPTION
Updated the geographical location to "Tokyo, Japan" (Previously is Japan, Tokyo which cause my name did not show when set the filter to Japan on Kubestronuat program page)