### PR TITLE
Set GB member priority to nil except for chair/vice chairs

### DIFF
--- a/people.json
+++ b/people.json
@@ -25090,7 +25090,7 @@
         "wechat": "",
         "website": "",
         "youtube": "",
-        "priority": 200,
+        "priority": "",
         "category": [
             "Governing Board"
         ],


### PR DESCRIPTION
## Summary
- Reset Dilpreet Bindra's priority from `200` to `""` (nil) to match all other regular GB members
- Chair (priority 300) and Vice Chairs (priority 200) retain their priority values

## Test plan
- [x] Verify only Dilpreet Bindra's priority changed
- [x] Confirm Chair and Vice Chairs still have their priority values
- [x] Validate `people.json` passes schema validation