### PR TITLE
Rename TOC Shadows to TOC Alternates on website

### DIFF
--- a/people.json
+++ b/people.json
@@ -49187,7 +49187,7 @@
         "website": "",
         "youtube": "",
         "priority": "",
-        "toc_role": "Shadow (GB)",
+        "toc_role": "Alternate (GB)",
         "category": [
             "Technical Oversight Committee",
             "End User TAB"
@@ -80299,7 +80299,7 @@
         "github": "https://github.com/raravena80",
         "bluesky": "https://raravena80.bsky.social",
         "slack_id": "D9PB03Y3G",
-        "toc_role": "Shadow (GB)",
+        "toc_role": "Alternate (GB)",
         "website": "https://serverbooter.com/",
         "category": [
             "Technical Oversight Committee",


### PR DESCRIPTION
The TOC collectively would like to rename the TOC shadows to TOC alternates as many times the elected person is already experienced. TOC Alternate more accurately describes the position.

Ref: https://github.com/cncf/toc/pull/2168