### PR TITLE
migrates the validate action to a supported runner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   verify-json-validation:
-    runs-on: oracle-2cpu-8gb-x86-64
+    runs-on: cncf-ubuntu-2-8-x86
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
I had a report from @cjyabraham of the validate action being queueed which I verified as being the case here 

https://github.com/cncf/people/actions/runs/31654462802/job/94305727400?pr=1791

During triage, I saw that the action was using a deprecated runner name. 

This change moves the action to run on `cncf-ubuntu-2-8-x86` which is the supported runner name.



