### PR TITLE
fix: remove whitespace from Shinhaeng Heo LinkedIn URL

### DIFF
--- a/people.json
+++ b/people.json
@@ -93913,7 +93913,7 @@
         "company": "MAYMUST",
         "pronouns": "He/Him",
         "location": "Hanam-si, Gyeonggi-do, South Korea",
-        "linkedin": "https://www.linkedin.com/in/ 신행-허-070b34277",
+        "linkedin": "https://www.linkedin.com/in/신행-허-070b34277",
         "twitter": "",
         "github": "https://github.com/si-naeng",
         "wechat": "",


### PR DESCRIPTION
## Why
My Kubestronaut profile's LinkedIn link returns a 404 because there is an unintended space immediately after `/in/`.

## What changed
Remove that single space from Shinhaeng Heo's LinkedIn URL in `people.json`.

## Validation
- Parsed the updated JSON successfully.
- Compared the parsed data against the base branch and verified that only the single space in this LinkedIn URL changed.
- `git diff --check` passed.

## Worklog
Located my profile entry, removed the space, and checked the complete diff. Schema validation will run in repository CI.